### PR TITLE
Get compat from hivemind node and futures HFs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dragos-roua/php-hive-tools",
+    "name": "fkosmala/php-hive-tools",
     "description": "PHP Tools to interact with the Hive blockchain.",
     "keywords": ["hive", "blockchain", "package"],
     "license": "MIT",
@@ -8,6 +8,10 @@
         {
             "name": "Dragos Roua",
             "email": "dragosroua@gmail.com"
+        },
+        {
+            "name": "Florent Kosmala",
+            "email": "kosflorent@gmail.com"
         }
     ],
     "type": "library",

--- a/src/HiveLayer.php
+++ b/src/HiveLayer.php
@@ -34,7 +34,7 @@ class HiveLayer {
     }
 
     public function call($method, $params = array(), $transport='curl') {
-        $request = $this->getRequest($method, $params);
+        $request = $this->getRequest('condenser_api.'.$method, $params);
         $response = '';
         if($transport == 'curl'){
         	$response = $this->curl($request);


### PR DESCRIPTION
I can't use some functions like getDiscussionsByAuthorBeforeDate or getContentReplies without having an "Invalid request" error from nodes.

That's why I update the layer to prfix it.